### PR TITLE
Enhance Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,19 @@ sudo: false
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
-  - 7.1.0alpha1
-  - hhvm
+  - 7.1
+  - 7.2
+  - 7.3
+  - nightly
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php: nightly
 
 before_script:
-  - travis_retry composer self-update
-  - composer require satooshi/php-coveralls --prefer-source
+  - if [[ $TRAVIS_PHP_VERSION != "5.6" ]]; then phpenv config-rm xdebug.ini; fi
 
 script:
-  - mkdir -p build/logs
-  - phpunit --coverage-clover build/logs/clover.xml
-
-after_script:
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php vendor/bin/coveralls -v; fi;'
+  - if [[ $TRAVIS_PHP_VERSION == "5.6" ]]; then make test-coveralls; else make test; fi

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ echo $time->is_monday;                  // false
 echo $time->is_saturday;                // true
 echo $time->is_today;                   // true
 echo $time->tomorrow;                   // 2013-02-04T00:00:00+0100
-echo $time->tomorrow->is_future         // true
+echo $time->tomorrow->is_future;        // true
 echo $time->yesterday;                  // 2013-02-02T00:00:00+0100
-echo $time->yesterday->is_past          // true
+echo $time->yesterday->is_past;         // true
 echo $time->monday;                     // 2013-01-28T00:00:00+0100
 echo $time->sunday;                     // 2013-02-03T00:00:00+0100
 
@@ -112,7 +112,7 @@ The implementation of the [DateTime][] class is vastly inspired by Ruby's
 ```php
 <?php
 
-use ICanBoogie\DateTime:
+use ICanBoogie\DateTime;
 
 $time = new DateTime('2014-01-06 11:11:11', 'utc'); // a monday at 11:11:11 UTC
 
@@ -322,7 +322,7 @@ use ICanBoogie\DateTime;
 
 // …
 
-$repository = new Repository($provider);
+/* @var Repository $repository */
 
 DateTime::$localizer = function(DateTime $instance, $locale) use ($repository) {
 
@@ -431,7 +431,7 @@ The package is continuously tested by [Travis CI](http://about.travis-ci.org/).
 [JsonSerializable interface]: http://php.net/manual/en/class.jsonserializable.php
 [documentation]:              http://api.icanboogie.org/datetime/latest/
 [DateTime]:                   http://api.icanboogie.org/datetime/latest/class-ICanBoogie.DateTime.html
-[TimeZone]:                   http://api.icanboogie.org/datetime/latest/class-ICanBoogie.TimeZone.html)
+[TimeZone]:                   http://api.icanboogie.org/datetime/latest/class-ICanBoogie.TimeZone.html
 [TimeZoneLocation]:           http://api.icanboogie.org/datetime/latest/class-ICanBoogie.TimeZoneLocation.html
 [PropertyNotDefined]:         http://api.icanboogie.org/common/1.2/class-ICanBoogie.PropertyNotDefined.html
 [PropertyNotWritable]:        http://api.icanboogie.org/common/1.2/class-ICanBoogie.PropertyNotWritable.html


### PR DESCRIPTION
# Changed log
- Add the `php-7.1`, `php-7.2` and `php-7.3` version tests because they're stable versions.
- The HHVM is split from `PHP-7.x`. Remove this and using the `nightly` version.
- The `php-7.1` is stable version currently, creating the code coverage report when using this version to do CI work.