### PR TITLE
Initialize coding style tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ before_script:
 
 script:
   - if [[ $TRAVIS_PHP_VERSION == "5.6" ]]; then make test-coveralls; else make test; fi
+  - if [[ $TRAVIS_PHP_VERSION == "5.6" ]]; then make check-coding-style; fi

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PACKAGE_VERSION = v1.2
 PHPUNIT_VERSION = phpunit-5.7.phar
 PHPUNIT_FILENAME = build/$(PHPUNIT_VERSION)
 PHPUNIT = php $(PHPUNIT_FILENAME)
+PHPCS_FILENAME = build/phpcs.phar
+PHPCS = php $(PHPCS_FILENAME)
+PHPCBF_FILENAME = build/phpcbf.phar
+PHPCBF = php $(PHPCBF_FILENAME)
 
 # do not edit the following lines
 
@@ -40,6 +44,20 @@ test-coveralls: test-dependencies
 	composer require --dev php-coveralls/php-coveralls
 	@$(PHPUNIT) --coverage-clover build/logs/clover.xml
 	php vendor/bin/php-coveralls -v
+
+check-coding-style:
+$(PHPCS_FILENAME):
+	wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar -O $(PHPCS_FILENAME)
+
+check-coding-style: $(PHPCS_FILENAME)
+	@$(PHPCS) --standard=phpcs.xml
+
+fix-coding-style:
+$(PHPCBF_FILENAME):
+	wget https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar -O $(PHPCBF_FILENAME)
+
+fix-coding-style: $(PHPCBF_FILENAME)
+	@$(PHPCBF) --standard=phpcs.xml
 
 doc: vendor
 	@mkdir -p build/docs

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="pcsg-generated-ruleset">
+    <description>ICanBoogie/DateTime coding style</description>
+
+    <file>./lib</file>
+    <file>./tests</file>
+
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n" />
+        </properties>
+    </rule>
+
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="150" />
+            <property name="absoluteLineLimit" value="200" />
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
# Changed log
- It's related to issue #24.
- Initialize `PHP_CodeSniffer` coding style tool installation and current setup.
- Initialize `phpcs.xml` setting and it includes the generic coding style sniffs. They're as follows:
  - `FileLineEnding`
  - `FileEndLineLength`

Other sniffs are available [here](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#genericfileslineendings), and I cannot find any sniff check about `snake_case` variables.

Perhaps we need to write own `sniff` classes for other coding style sniff check.

@olvlvl, could you suggest some recommendations on this?

I think we should add other sniff rules in `phpcs.xml` setting.