### PR TITLE
Add constant type to overridden DateTime::COOKIE

### DIFF
--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -173,7 +173,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	 *
 	 * @see http://grokbase.com/t/php/php-bugs/111xynxd6m/php-bug-bug-53879-new-datetime-createfromformat-fails-to-parse-cookie-expiration-date
 	 */
-	public const COOKIE = 'l, d-M-Y H:i:s T';
+	public const string COOKIE = 'l, d-M-Y H:i:s T';
 
 	/**
 	 * DB (example: 2013-02-03 20:59:03)


### PR DESCRIPTION
Constant properties are allowed since PHP 8.3. With 8.4, I'm getting the following error when the constant type is not explicitly specified:

```
Fatal error: Type of ICanBoogie\DateTime::COOKIE must be compatible with DateTimeInterface::COOKIE of type string in /home/.../vendor/icanboogie/datetime/lib/DateTime.php on line 169
```